### PR TITLE
Remove auto-fetch behavior and remove tags from refs

### DIFF
--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -229,15 +229,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Don't attempt periodic upstream fetches
-	// log.Println("Starting background fetches...")
-	// cancel := goblet.RunEvery(5*time.Minute, func(t time.Time) {
-	// 	for _, err := range FetchRepositories(config, configFile.Repositories, false) {
-	// 		log.Println(err)
-	// 	}
-	// })
-	// defer cancel()
-
 	log.Println("Registering HTTP routes...")
 	http.Handle("/", goblet.HTTPHandler(config))
 

--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -229,14 +229,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Schedule periodic upstream fetches every 15 minutes.
-	log.Println("Starting background fetches...")
-	cancel := goblet.RunEvery(5*time.Minute, func(t time.Time) {
-		for _, err := range FetchRepositories(config, configFile.Repositories, false) {
-			log.Println(err)
-		}
-	})
-	defer cancel()
+	// Don't attempt periodic upstream fetches
+	// log.Println("Starting background fetches...")
+	// cancel := goblet.RunEvery(5*time.Minute, func(t time.Time) {
+	// 	for _, err := range FetchRepositories(config, configFile.Repositories, false) {
+	// 		log.Println(err)
+	// 	}
+	// })
+	// defer cancel()
 
 	log.Println("Registering HTTP routes...")
 	http.Handle("/", goblet.HTTPHandler(config))

--- a/managed_repository.go
+++ b/managed_repository.go
@@ -298,9 +298,7 @@ func (r *managedRepository) fetchUpstreamInternal(remote string, token *oauth2.T
 	args = append(args, remote)
 
 	// refspecs
-	var refspecBuilder strings.Builder
-	runGitWithStdOut(noopOperation{}, &refspecBuilder, r.localDiskPath, "config", fmt.Sprintf("remote.%s.fetch", remote))
-	args = append(args, strings.TrimSpace(refspecBuilder.String()))
+	args = append(args, "+refs/heads/*:refs/remotes/origin/*")
 	args = append(args, "^refs/pull/*")
 	if len(additionalWants) >= 1 {
 		// only the first want will be appended


### PR DESCRIPTION
This PR removes Goblet's default behavior of fetching every 5 minutes. It also updates the refs for fetching to specify only branches (not tags).