### PR TITLE
goblet: load initial from peer

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ import (
 type ConfigFile struct {
 	Port                    int      `json:"port"`
 	CacheRoot               string   `json:"cache_root"`
+	PeerLoadBalancer        string   `json:"peer_load_balancer,omitempty"`
 	TokenExpiryDeltaSeconds int      `json:"token_expiry_delta_seconds"`
 	EnableMetrics           bool     `json:"enable_metrics,omitempty"`
 	PackObjectsHook         string   `json:"pack_objects_hook,omitempty"`

--- a/example_config.json
+++ b/example_config.json
@@ -1,6 +1,7 @@
 {
   "port": 8080,
   "cache_root": "/tmp/goblet",
+  "peer_load_balancer": "http://goblet.svc.cluster.local:8080",
   "token_expiry_delta_seconds": 300,
   "enable_metrics": true,
   "repositories": [

--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -177,6 +177,7 @@ func main() {
 
 	config := &goblet.ServerConfig{
 		LocalDiskCacheRoot:         configFile.CacheRoot,
+		PeerLoadBalancer:           configFile.PeerLoadBalancer,
 		URLCanonicalizer:           github.URLCanonicalizer,
 		RequestAuthorizer:          goblet.NoOpRequestAuthorizer,
 		TokenSource:                ts,

--- a/goblet.go
+++ b/goblet.go
@@ -71,6 +71,8 @@ var (
 type ServerConfig struct {
 	LocalDiskCacheRoot string
 
+	PeerLoadBalancer string
+
 	URLCanonicalizer func(*url.URL) (*url.URL, error)
 
 	RequestAuthorizer func(*http.Request) error


### PR DESCRIPTION
On the initial repo load, try to pull from another goblet instance behind the load balancer. Then, if that fails (ie, for first goblet instance, use the upstream github)