### PR TITLE
goblet: add hostname to logs

### DIFF
--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -126,6 +126,10 @@ func FetchRepositories(config *goblet.ServerConfig, repositories []string, mustF
 func main() {
 	flag.Parse()
 
+	if containerID, err := os.Hostname(); err == nil {
+		log.SetPrefix(fmt.Sprintf("[%s] ", containerID))
+	}
+
 	if *config == "" {
 		log.Fatal("The '-config' argument is mandatory")
 	}


### PR DESCRIPTION
https://app.asana.com/1/10497086658021/project/1160461986422257/task/1213161982400545?focus=true

In ECS Fargate, hostname==container id