### PR TITLE
Update Go to 1.26 and build image to Debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS build-env
+FROM golang:1.26-trixie AS build-env
 
 RUN apt-get update && apt-get install -y gcc cmake pkg-config
 

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ package goblet
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // ConfigFile holds the configuration for Goblet server instances.
@@ -33,7 +33,7 @@ type ConfigFile struct {
 // LoadConfigFile reads a Goblet configuration file.
 func LoadConfigFile(path string) (ConfigFile, error) {
 	file := ConfigFile{}
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return file, err
 	}

--- a/github/app.go
+++ b/github/app.go
@@ -19,7 +19,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"log"
 	"net/http"
 	"time"
@@ -63,7 +64,7 @@ func getInstallationAccessToken(jwt string, installationID string) (oauth2.Token
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	resBytes, err := ioutil.ReadAll(res.Body)
+	resBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Printf("GitHub App token response read failed (url:%s, err:%v)\n", url, err)
 		return oauth2.Token{}, err
@@ -97,7 +98,7 @@ func getInstallationAccessToken(jwt string, installationID string) (oauth2.Token
 	}
 
 	return oauth2.Token{
-		AccessToken: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("x-access-token:%s", resData.Token))),
+		AccessToken: base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "x-access-token:%s", resData.Token)),
 		TokenType:   "Basic",
 		Expiry:      exp,
 	}, nil

--- a/github/authorizer.go
+++ b/github/authorizer.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"log"
 	"net/http"
 	"net/url"
@@ -146,7 +147,7 @@ func isTokenValid(token string, repoURL string) (bool, bool, error) {
 	// Log GitHub rate limit headers
 	logGitHubRateLimitHeaders("TokenValidation", infoRefsURL, res)
 
-	resBytes, err := ioutil.ReadAll(res.Body)
+	resBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Printf("GitHub authorization response read failed (url:%s, err:%v)\n", infoRefsURL, err)
 		return false, true, err
@@ -159,7 +160,7 @@ func isTokenValid(token string, repoURL string) (bool, bool, error) {
 		log.Printf("Token validation failed (status=%d, url=%s, body_preview=%s)\n",
 			res.StatusCode, infoRefsURL, truncateString(string(resBytes), 200))
 		err = errors.New(string(resBytes))
-		log.Printf("GitHub authorization failed with non-OK response (url:%s, status:%d, content-type:%s, error:%s)\n", 
+		log.Printf("GitHub authorization failed with non-OK response (url:%s, status:%d, content-type:%s, error:%s)\n",
 			infoRefsURL, res.StatusCode, res.Header.Get("Content-Type"), string(resBytes))
 
 		// should not cache result if statusCode matches these, so next authorization attempt will retry

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canva/goblet
 
-go 1.24.0
+go 1.26.1
 
 require (
 	github.com/DataDog/opencensus-go-exporter-datadog v0.0.0-20210527074920-9baf37265e83

--- a/goblet-server/main.go
+++ b/goblet-server/main.go
@@ -261,7 +261,7 @@ type logBasedOperation struct {
 	u      *url.URL
 }
 
-func (op *logBasedOperation) Printf(format string, a ...interface{}) {
+func (op *logBasedOperation) Printf(format string, a ...any) {
 	// log.Printf("Progress %s (%s): %s", op.action, op.u.String(), fmt.Sprintf(format, a...))
 }
 

--- a/goblet.go
+++ b/goblet.go
@@ -89,7 +89,7 @@ type ServerConfig struct {
 }
 
 type RunningOperation interface {
-	Printf(format string, a ...interface{})
+	Printf(format string, a ...any)
 
 	Done(error)
 }
@@ -191,12 +191,12 @@ func DefaultURLCanonicalizer(u *url.URL) (*url.URL, error) {
 	ret.Path = u.Path
 
 	// Git endpoint suffixes.
-	if strings.HasSuffix(ret.Path, "/info/refs") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/info/refs")
-	} else if strings.HasSuffix(ret.Path, "/git-upload-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-upload-pack")
-	} else if strings.HasSuffix(ret.Path, "/git-receive-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-receive-pack")
+	if before, ok := strings.CutSuffix(ret.Path, "/info/refs"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-upload-pack"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-receive-pack"); ok {
+		ret.Path = before
 	}
 	ret.Path = strings.TrimSuffix(ret.Path, ".git")
 	return &ret, nil

--- a/google/hooks.go
+++ b/google/hooks.go
@@ -85,19 +85,19 @@ func NewRequestAuthorizer(ts oauth2.TokenSource) (func(*http.Request) error, err
 
 func authorizeAuthzHeader(oauth2Service *oauth2cli.Service, email, authorizationHeader string) error {
 	accessToken := ""
-	if strings.HasPrefix(authorizationHeader, "Bearer ") {
-		accessToken = strings.TrimPrefix(authorizationHeader, "Bearer ")
-	} else if strings.HasPrefix(authorizationHeader, "Basic ") {
-		bs, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(authorizationHeader, "Basic "))
+	if after, ok := strings.CutPrefix(authorizationHeader, "Bearer "); ok {
+		accessToken = after
+	} else if after, ok := strings.CutPrefix(authorizationHeader, "Basic "); ok {
+		bs, err := base64.StdEncoding.DecodeString(after)
 		if err != nil {
 			return status.Error(codes.Unauthenticated, "cannot parse the Authorization header")
 		}
 		s := string(bs)
-		i := strings.IndexByte(s, ':')
-		if i < 0 {
+		_, after, ok := strings.Cut(s, ":")
+		if !ok {
 			return status.Error(codes.Unauthenticated, "cannot parse the Authorization header")
 		}
-		accessToken = s[i+1:]
+		accessToken = after
 	} else {
 		return status.Error(codes.Unauthenticated, "no bearer token")
 	}
@@ -156,12 +156,12 @@ func CanonicalizeURL(u *url.URL) (*url.URL, error) {
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported host: %s", u.Host)
 	}
 	// Git endpoint suffixes.
-	if strings.HasSuffix(ret.Path, "/info/refs") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/info/refs")
-	} else if strings.HasSuffix(ret.Path, "/git-upload-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-upload-pack")
-	} else if strings.HasSuffix(ret.Path, "/git-receive-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-receive-pack")
+	if before, ok := strings.CutSuffix(ret.Path, "/info/refs"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-upload-pack"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-receive-pack"); ok {
+		ret.Path = before
 	}
 	ret.Path = strings.TrimSuffix(ret.Path, ".git")
 	return &ret, nil
@@ -170,7 +170,7 @@ func CanonicalizeURL(u *url.URL) (*url.URL, error) {
 func scopeCheck(scopes string) (bool, bool) {
 	hasCloudPlatform := false
 	hasUserInfoEmail := false
-	for _, scope := range strings.Split(scopes, " ") {
+	for scope := range strings.SplitSeq(scopes, " ") {
 		if scope == scopeCloudPlatform {
 			hasCloudPlatform = true
 		}

--- a/managed_repository.go
+++ b/managed_repository.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+
 	"log"
 	"net/http"
 	"net/url"
@@ -79,12 +79,12 @@ func getManagedRepo(localDiskPath string, u *url.URL, config *ServerConfig) *man
 	ret := m.(*managedRepository)
 	if !loaded {
 		log.Printf("FetchUpstreamPool created for %s\n", localDiskPath)
-		ret.fetchUpstreamPool = pond.New(1, 1000, pond.IdleTimeout(5*time.Minute), pond.PanicHandler(func(p interface{}) {
+		ret.fetchUpstreamPool = pond.New(1, 1000, pond.IdleTimeout(5*time.Minute), pond.PanicHandler(func(p any) {
 			log.Printf("Fetch upstream task panicked: %v\n", p)
 		}))
 
 		log.Printf("ServeFetchPool created for %s\n", localDiskPath)
-		ret.serveFetchPool = pond.New(100, 1000, pond.IdleTimeout(5*time.Minute), pond.PanicHandler(func(p interface{}) {
+		ret.serveFetchPool = pond.New(100, 1000, pond.IdleTimeout(5*time.Minute), pond.PanicHandler(func(p any) {
 			log.Printf("Serve fetch task panicked: %v\n", p)
 		}))
 
@@ -206,7 +206,7 @@ func (r *managedRepository) lsRefsUpstream(command []*gitprotocolio.ProtocolV2Re
 
 	if resp.StatusCode != http.StatusOK {
 		errMessage := ""
-		bs, err := ioutil.ReadAll(resp.Body)
+		bs, err := io.ReadAll(resp.Body)
 		if err == nil {
 			errMessage = string(bs)
 		}
@@ -549,8 +549,8 @@ func newGitRequest(command []*gitprotocolio.ProtocolV2RequestChunk) io.Reader {
 
 type noopOperation struct{}
 
-func (noopOperation) Printf(string, ...interface{}) {}
-func (noopOperation) Done(error)                    {}
+func (noopOperation) Printf(string, ...any) {}
+func (noopOperation) Done(error)            {}
 
 type operationWriter struct {
 	op RunningOperation

--- a/testing/test_proxy_server.go
+++ b/testing/test_proxy_server.go
@@ -16,7 +16,6 @@ package testing
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -89,7 +88,7 @@ func NewTestServer(config *TestServerConfig) *TestServer {
 	}
 
 	{
-		dir, err := ioutil.TempDir("", "goblet_cache")
+		dir, err := os.MkdirTemp("", "goblet_cache")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -125,12 +124,12 @@ func (s *TestServer) testURLCanonicalizer(u *url.URL) (*url.URL, error) {
 	ret.Path = u.Path
 
 	// Git endpoint suffixes.
-	if strings.HasSuffix(ret.Path, "/info/refs") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/info/refs")
-	} else if strings.HasSuffix(ret.Path, "/git-upload-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-upload-pack")
-	} else if strings.HasSuffix(ret.Path, "/git-receive-pack") {
-		ret.Path = strings.TrimSuffix(ret.Path, "/git-receive-pack")
+	if before, ok := strings.CutSuffix(ret.Path, "/info/refs"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-upload-pack"); ok {
+		ret.Path = before
+	} else if before, ok := strings.CutSuffix(ret.Path, "/git-receive-pack"); ok {
+		ret.Path = before
 	}
 	ret.Path = strings.TrimSuffix(ret.Path, ".git")
 	return ret, nil
@@ -195,7 +194,7 @@ func TestRequestAuthorizer(r *http.Request) error {
 type GitRepo string
 
 func NewLocalBareGitRepo() GitRepo {
-	dir, err := ioutil.TempDir("", "goblet_tmp")
+	dir, err := os.MkdirTemp("", "goblet_tmp")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -205,7 +204,7 @@ func NewLocalBareGitRepo() GitRepo {
 }
 
 func NewLocalGitRepo() GitRepo {
-	dir, err := ioutil.TempDir("", "goblet_tmp")
+	dir, err := os.MkdirTemp("", "goblet_tmp")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -251,7 +250,7 @@ func (c *commandError) Error() string {
 		fmt.Sprintf("Error: %v", c.err),
 		fmt.Sprintf("Args: %#v", c.args),
 	}
-	for _, s := range strings.Split(c.output, "\n") {
+	for s := range strings.SplitSeq(c.output, "\n") {
 		ss = append(ss, "Output: "+s)
 	}
 	return strings.Join(ss, "\n")


### PR DESCRIPTION
- Update Go from 1.24 to 1.26.1
- Update build base image from Debian bookworm to trixie (now current stable)
- Runtime image (Ubuntu 24.04) is already the latest LTS, unchanged
- Run `go fix ./...` to modernize deprecated APIs (`ioutil` → `os`/`io`, `interface{}` → `any`, `CutPrefix`/`CutSuffix`, `SplitSeq`, `fmt.Appendf`)