### PR TITLE
Add pass-through LFS proxy support

### DIFF
--- a/goblet.go
+++ b/goblet.go
@@ -197,6 +197,8 @@ func DefaultURLCanonicalizer(u *url.URL) (*url.URL, error) {
 		ret.Path = before
 	} else if before, ok := strings.CutSuffix(ret.Path, "/git-receive-pack"); ok {
 		ret.Path = before
+	} else if idx := strings.Index(ret.Path, "/info/lfs/"); idx >= 0 {
+		ret.Path = ret.Path[:idx]
 	}
 	ret.Path = strings.TrimSuffix(ret.Path, ".git")
 	return &ret, nil

--- a/http_proxy_server.go
+++ b/http_proxy_server.go
@@ -68,6 +68,12 @@ func (s *httpProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		reporter.reportError(err)
 		return
 	}
+
+	if isLFSRequest(r) {
+		s.lfsHandler(reporter, w, r)
+		return
+	}
+
 	if proto := r.Header.Get("Git-Protocol"); proto != "version=2" {
 		reporter.reportError(status.Errorf(codes.InvalidArgument, "accepts only Git protocol v2, received %v", proto))
 		return

--- a/lfs_proxy.go
+++ b/lfs_proxy.go
@@ -1,0 +1,75 @@
+package goblet
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func isLFSRequest(r *http.Request) bool {
+	return strings.Contains(r.URL.Path, "/info/lfs/")
+}
+
+func (s *httpProxyServer) lfsHandler(reporter *httpErrorReporter, w http.ResponseWriter, r *http.Request) {
+	if !strings.HasSuffix(r.URL.Path, "/info/lfs/objects/batch") {
+		reporter.reportError(status.Error(codes.Unimplemented, "only LFS batch API is supported"))
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		reporter.reportError(status.Error(codes.InvalidArgument, "LFS batch API requires POST"))
+		return
+	}
+
+	// Use the canonicalizer to resolve the upstream host/scheme, but
+	// preserve the original request path since GitHub's LFS API is
+	// case-sensitive (the GitHub canonicalizer lowercases the path).
+	originalPath := r.URL.Path
+	canonicalURL, err := s.config.URLCanonicalizer(r.URL)
+	if err != nil {
+		reporter.reportError(status.Errorf(codes.Internal, "cannot canonicalize URL: %v", err))
+		return
+	}
+	upstreamURL := *canonicalURL
+	upstreamURL.Path = originalPath
+
+	t, err := s.config.TokenSource.Token()
+	if err != nil {
+		reporter.reportError(status.Errorf(codes.Internal, "cannot obtain OAuth2 token: %v", err))
+		return
+	}
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), r.Body)
+	if err != nil {
+		reporter.reportError(status.Errorf(codes.Internal, "cannot create upstream request: %v", err))
+		return
+	}
+
+	upstreamReq.Header.Set("Content-Type", "application/vnd.git-lfs+json")
+	upstreamReq.Header.Set("Accept", "application/vnd.git-lfs+json")
+	t.SetAuthHeader(upstreamReq)
+
+	startTime := time.Now()
+	resp, err := http.DefaultClient.Do(upstreamReq)
+	if err != nil {
+		log.Printf("LFS batch request failed (url:%s, err:%v)\n", upstreamURL.String(), err)
+		reporter.reportError(status.Errorf(codes.Internal, "upstream LFS request failed: %v", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	log.Printf("LFS batch response (url:%s, status:%d, duration:%s)\n", upstreamURL.String(), resp.StatusCode, time.Since(startTime))
+
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}

--- a/testing/end2end/lfs_test.go
+++ b/testing/end2end/lfs_test.go
@@ -1,0 +1,145 @@
+package end2end
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	goblettest "github.com/canva/goblet/testing"
+)
+
+type lfsBatchRequest struct {
+	Operation string          `json:"operation"`
+	Objects   []lfsBatchObject `json:"objects"`
+}
+
+type lfsBatchObject struct {
+	OID  string `json:"oid"`
+	Size int64  `json:"size"`
+}
+
+type lfsBatchResponse struct {
+	Transfer string `json:"transfer"`
+	Objects  []struct {
+		OID     string `json:"oid"`
+		Size    int64  `json:"size"`
+		Actions map[string]struct {
+			Href string `json:"href"`
+		} `json:"actions"`
+	} `json:"objects"`
+}
+
+func TestLFSBatch_ProxiesRequest(t *testing.T) {
+	ts := goblettest.NewTestServer(&goblettest.TestServerConfig{
+		RequestAuthorizer: goblettest.TestRequestAuthorizer,
+		TokenSource:       goblettest.TestTokenSource,
+	})
+	defer ts.Close()
+
+	reqBody := lfsBatchRequest{
+		Operation: "download",
+		Objects: []lfsBatchObject{
+			{OID: "abc123", Size: 100},
+			{OID: "def456", Size: 200},
+		},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	url := ts.ProxyServerURL + "repo.git/info/lfs/objects/batch"
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
+	req.Header.Set("Accept", "application/vnd.git-lfs+json")
+	req.Header.Set("Authorization", "Bearer "+goblettest.ValidClientAuthToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var batchResp lfsBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&batchResp); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(batchResp.Objects) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(batchResp.Objects))
+	}
+	for i, obj := range batchResp.Objects {
+		if obj.OID != reqBody.Objects[i].OID {
+			t.Errorf("object %d: expected OID %s, got %s", i, reqBody.Objects[i].OID, obj.OID)
+		}
+		dl, ok := obj.Actions["download"]
+		if !ok {
+			t.Errorf("object %d: missing download action", i)
+		} else if dl.Href == "" {
+			t.Errorf("object %d: empty download href", i)
+		}
+	}
+}
+
+func TestLFSBatch_RequiresAuth(t *testing.T) {
+	ts := goblettest.NewTestServer(&goblettest.TestServerConfig{
+		RequestAuthorizer: goblettest.TestRequestAuthorizer,
+		TokenSource:       goblettest.TestTokenSource,
+	})
+	defer ts.Close()
+
+	reqBody := lfsBatchRequest{
+		Operation: "download",
+		Objects:   []lfsBatchObject{{OID: "abc123", Size: 100}},
+	}
+	body, _ := json.Marshal(reqBody)
+
+	url := ts.ProxyServerURL + "repo.git/info/lfs/objects/batch"
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestLFSBatch_UnsupportedPathReturns501(t *testing.T) {
+	ts := goblettest.NewTestServer(&goblettest.TestServerConfig{
+		RequestAuthorizer: goblettest.TestRequestAuthorizer,
+		TokenSource:       goblettest.TestTokenSource,
+	})
+	defer ts.Close()
+
+	url := ts.ProxyServerURL + "repo.git/info/lfs/locks"
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+goblettest.ValidClientAuthToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", resp.StatusCode)
+	}
+}

--- a/testing/test_proxy_server.go
+++ b/testing/test_proxy_server.go
@@ -15,7 +15,9 @@
 package testing
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -130,6 +132,8 @@ func (s *TestServer) testURLCanonicalizer(u *url.URL) (*url.URL, error) {
 		ret.Path = before
 	} else if before, ok := strings.CutSuffix(ret.Path, "/git-receive-pack"); ok {
 		ret.Path = before
+	} else if idx := strings.Index(ret.Path, "/info/lfs/"); idx >= 0 {
+		ret.Path = ret.Path[:idx]
 	}
 	ret.Path = strings.TrimSuffix(ret.Path, ".git")
 	return ret, nil
@@ -138,6 +142,11 @@ func (s *TestServer) testURLCanonicalizer(u *url.URL) (*url.URL, error) {
 func (s *TestServer) upstreamServerHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Header.Get("Authorization") != "Bearer "+validServerAuthToken {
 		http.Error(w, "invalid authenticator", http.StatusForbidden)
+		return
+	}
+
+	if strings.Contains(req.URL.Path, "/info/lfs/") {
+		s.upstreamLFSHandler(w, req)
 		return
 	}
 
@@ -162,6 +171,62 @@ func (s *TestServer) upstreamServerHandler(w http.ResponseWriter, req *http.Requ
 		req.TransferEncoding = nil
 	}
 	h.ServeHTTP(w, req)
+}
+
+func (s *TestServer) upstreamLFSHandler(w http.ResponseWriter, req *http.Request) {
+	if !strings.HasSuffix(req.URL.Path, "/info/lfs/objects/batch") {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if req.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	var batchReq struct {
+		Operation string `json:"operation"`
+		Objects   []struct {
+			OID  string `json:"oid"`
+			Size int64  `json:"size"`
+		} `json:"objects"`
+	}
+	if err := json.Unmarshal(body, &batchReq); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	type action struct {
+		Href string `json:"href"`
+	}
+	type object struct {
+		OID     string            `json:"oid"`
+		Size    int64             `json:"size"`
+		Actions map[string]action `json:"actions"`
+	}
+	resp := struct {
+		Transfer string   `json:"transfer"`
+		Objects  []object `json:"objects"`
+	}{
+		Transfer: "basic",
+	}
+	for _, obj := range batchReq.Objects {
+		resp.Objects = append(resp.Objects, object{
+			OID:  obj.OID,
+			Size: obj.Size,
+			Actions: map[string]action{
+				"download": {Href: fmt.Sprintf("https://fake-storage.example.com/%s", obj.OID)},
+			},
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (s *TestServer) CreateRandomCommitUpstream() (string, error) {


### PR DESCRIPTION
Adds a pass-through proxy for Git LFS batch API requests. LFS requests (`POST /info/lfs/objects/batch`) are detected before the Git protocol v2 check, authenticated via `RequestAuthorizer`, and forwarded upstream with the server's OAuth2 token. The response (containing download URLs) is streamed back to the client.

This is a pass-through proxy — no LFS object caching. Per the [Basic Transfer API spec](https://github.com/git-lfs/git-lfs/blob/main/docs/api/basic-transfers.md), download URLs are returned in the batch response's `actions.download.href` field, which for GitHub points to external cloud storage. Clients fetch objects directly from those URLs, bypassing Goblet.

#### LFS endpoints

**Read paths** (relevant for Goblet):
- `POST /info/lfs/objects/batch` — Batch API for discovering download/upload URLs **(currently supported)**
- `GET /info/lfs/objects/:oid` — Direct object download via "basic" transfer. Some servers support this as a fallback, but GitHub uses the batch API exclusively and returns signed S3 URLs in the batch response, so this is unlikely to be hit.

**Write paths** (not relevant — Goblet is read-only):
- `POST /info/lfs/objects` — Legacy single-object upload (deprecated)
- `POST /info/lfs/locks` — Create a lock
- `POST /info/lfs/locks/verify` — List locks for pre-push verification
- `POST /info/lfs/locks/:id/unlock` — Delete a lock

Unsupported `/info/lfs/` paths return HTTP 501.

Spec references: [Batch API](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md), [Basic Transfers](https://github.com/git-lfs/git-lfs/blob/main/docs/api/basic-transfers.md), [File Locking](https://github.com/git-lfs/git-lfs/blob/main/docs/api/locking.md)

#### Notes to Reviewers

LFS routing intentionally sits between `RequestAuthorizer` and the `Git-Protocol: version=2` check, since LFS uses its own HTTP/JSON protocol rather than Git wire protocol.


#### Test Plan

I manually validated it by doing the following:

* Created a build with personal access token support auth support (see https://github.com/figma/goblet/commit/e8fb90095f4283f74509cfc056998eed3a349a1c which is atop this branch).

Then with that checked out locally:

```bash
cat > /tmp/goblet-config.json <<'EOF'
 {
    "port": 8080,
    "cache_root": "/tmp/goblet",
    "token_expiry_delta_seconds": 300,
    "repositories": [
     "https://github.com/Schoonology/git-lfs-test.git"
   ]
 }
 EOF

docker build -t goblet-local .

docker run --rm -p 8080:8080 \
  -e GH_TOKEN="$(gh auth token)" \
  -v /tmp/goblet-config.json:/app/config.json \
  goblet-local -config /app/config.json
```

Then watch this succeed in another terminal:

```
git clone -c protocol.version=2 \
    -c http.https://github.com.proxy=http://localhost:8080 \
    https://github.com/Schoonology/git-lfs-test.git /tmp/lfs-proxy-test
```