### PR TITLE
ci: Use PR head SHA for Docker image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           images: ghcr.io/figma/goblet
           tags: |
-            type=raw,value=sha-${{ github.event.pull_request.head.sha || github.sha }}
+            type=raw,value=${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           images: ghcr.io/figma/goblet
           tags: |
-            type=sha,format=long
+            type=raw,value=sha-${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
On `pull_request` triggers, `github.sha` points to the ephemeral merge commit (`refs/pull/N/merge`), not the branch HEAD. This means `type=sha,format=long` tags the image with a SHA that doesn't correspond to any real commit in the repo.

Switch to `type=raw` using `github.event.pull_request.head.sha` so the tag matches the actual commit. Falls back to `github.sha` on push events (where it's already the real commit).